### PR TITLE
Fix IIF word order

### DIFF
--- a/docs/t-sql/functions/logical-functions-iif-transact-sql.md
+++ b/docs/t-sql/functions/logical-functions-iif-transact-sql.md
@@ -53,10 +53,10 @@ IIF ( boolean_expression, true_value, false_value )
  *boolean_expression* が false に評価された場合に返す値。  
   
 ## <a name="return-types"></a>戻り値の型  
- 内の型からの優先順位が最も高いデータ型を返します *true_value* と *false_value* です。 詳細については、「[データ型の優先順位 &#40;Transact-SQL&#41;](../../t-sql/data-types/data-type-precedence-transact-sql.md)」を参照してください。  
+ *true_value* および *false_value* の型から最も優先順位の高い型を返します。 詳細については、「[データ型の優先順位 &#40;Transact-SQL&#41;](../../t-sql/data-types/data-type-precedence-transact-sql.md)」を参照してください。  
   
 ## <a name="remarks"></a>解説  
- IIF は CASE 式の簡略版です。 最初の引数として渡されたブール式を評価し、評価の結果に基づいて他の 2 つの引数のいずれかを返します。 つまり、 *true_value* ブール式が true の場合、返されると、 *false_value* ブール式が false または不明のかどうかに返されます。 任意の型の *true_value* と *false_value* を指定できます。 ブール式、NULL 処理、および戻り値の型に対する CASE 式に適用されるのと同じ規則が IIF にも適用されます。 詳細については、を参照してください。 [CASE &#40;Transact-SQL&#41;](../../t-sql/language-elements/case-transact-sql.md).  
+ IIF は CASE 式の簡略版です。 最初の引数として渡されたブール式を評価し、評価の結果に基づいて他の 2 つの引数のいずれかを返します。 つまり、ブール式が true の場合、 *true_value* を返し、 ブール式が false または不明の場合には、*false_value* を返します。 任意の型の *true_value* と *false_value* を指定できます。 ブール式、NULL 処理、および戻り値の型に対する CASE 式に適用されるのと同じ規則が IIF にも適用されます。 詳細については、「[CASE &#40;Transact-SQL&#41;](../../t-sql/language-elements/case-transact-sql.md)」を参照してください。
   
  IIF が CASE に変換されるという事実は、この関数の動作の他の側面にも影響を与えます。 CASE 式では最大 10 のレベルまで入れ子が許容されるため、IIF ステートメントでも最大 10 のレベルまで入れ子が許容されます。 また、IIF では、意味が同等の CASE 式として他のサーバーにリモート処理を行い、リモート処理された CASE 式のすべての動作を実行します。  
   


### PR DESCRIPTION
 Fix Logical Functions IIF word order
- Fix word order. 
original : 'Returns the data type with the highest precedence from the types in true_value and false_value.'
before : '内の型からの優先順位が最も高いデータ型を返します true_value と false_value です。'
after : 'true_value および false_value の型から最も優先順位の高い型を返します。'
- Fix word order. 
original : 'That is, the true_value is returned if the Boolean expression is true, and the false_value is returned if the Boolean expression is false or unknown.'
before : 'つまり、 true_value ブール式が true の場合、返されると、 false_value ブール式が false または不明のかどうかに返されます。'
after : 'つまり、ブール式が true の場合、 true_value を返し、 ブール式が false または不明の場合には、false_value を返します。'
- Fix word order. 
original : 'For more information, see CASE (Transact-SQL).'
before : '詳細については、を参照してください。 CASE (Transact-SQL).'
after : '詳細については、「CASE (Transact-SQL)」を参照してください。'